### PR TITLE
Replace usage of Tail function with ReadLine, also add setting for auto toggling zone images depending on zone

### DIFF
--- a/lib/config.ahk
+++ b/lib/config.ahk
@@ -22,6 +22,7 @@ global imagesYoffset := 0
 
 global treeSide := "Right"
 global treeName := "tree.jpg"
+global autoToggleZoneImages := "False"
 global opacity := 180
 global startHidden := "False"
 global displayTimeout := 0
@@ -105,6 +106,8 @@ IniRead, imagesYoffset, %ININame%, Offset, imagesYoffset, %imagesYoffset%
 
 IniRead, treeSide, %ININame%, Options, treeSide, %treeSide%
 IniRead, treeName, %ININame%, Options, treeName, %treeName%
+IniRead, autoToggleZoneImages, %ININame%, Options, autoToggleZoneImages, %autoToggleZoneImages%
+
 IniRead, opacity, %ININame%, Options, opacity, %opacity%
 IniRead, startHidden, %ININame%, Options, startHidden, %startHidden%
 IniRead, displayTimeout, %ININame%, Options, displayTimeout, %displayTimeout%
@@ -231,6 +234,7 @@ WriteAll() {
 
   IniWrite, %treeSide%, %ININame%, Options, treeSide
   IniWrite, %treeName%, %ININame%, Options, treeName
+  IniWrite, %autoToggleZoneImages%, %ININame%, Options, autoToggleZoneImages
   IniWrite, %opacity%, %ININame%, Options, opacity
   IniWrite, %startHidden%, %ININame%, Options, startHidden
   IniWrite, %displayTimeout%, %ININame%, Options, displayTimeout

--- a/lib/search.ahk
+++ b/lib/search.ahk
@@ -120,8 +120,19 @@ SearchLog() {
     } ;end level up logic
 
     travel := "You have entered"
-    IfInString, log, %travel%
+    IfInString, newLogLines, %travel%
     {
+      If autoToggleZoneImages 
+      {
+        zone_toggle := 1
+        places_disabled_zones :=  ["Hideout","Rogue Harbour", "Oriath", "Lioneye's Watch", "The Forest Encampment", "The Sarn Encampment", "Highgate", "Overseer's Tower", "The Bridge Encampment", "Oriath Docks"]
+        For _, zone in places_disabled_zones
+          IfInString, newLogLines, %zone% 
+          {
+            zone_toggle := 0
+            break
+          }
+      }
       activeCount := 0
       active_toggle := 1
 

--- a/lib/search.ahk
+++ b/lib/search.ahk
@@ -60,30 +60,27 @@ RotateZone(direction, zones, act, current) {
 
 SearchLog() {
   global
-  log := Tail(1, client)
-  ;Only bother checking if the log has changed or someone manually changed Part
-  If (log != oldLog or trigger) {
-    oldLog := log
+  ;Only bother checking if the newLogLines has changed or someone manually changed Part
+  newLogLines := client_txt_file.Read()
+  If (newLogLines or trigger) {
     trigger := false
-    DND := "DND mode is now ON"
-    IfInString, log, %DND%
-    {
-      log := Tail(2, client)
-    }
     levelUp := charName ;check character name is present first
-    IfInString, log, %levelUp%
+    IfInString, newLogLines, %levelUp%
     {
       levelUp := "is now level"
-      IfInString, log, %levelUp%
+
+      IfInString, newLogLines, %levelUp%
       {
-        levelPos := InStr(log, levelUp, false)
-        newLevel := SubStr(log, levelPos+13, 2)
+        levelPos := InStr(newLogLines, levelUp, false)
+        newLevel := SubStr(newLogLines, levelPos+13, 2)
         nextLevel := newLevel + 1
         ;So levels stay in order
-        If (newLevel < 10){
+        If (newLevel < 10)
+        {
           newLevel := "0" . newLevel
         }
-        If (nextLevel < 10){
+        If (nextLevel < 10)
+        {
           nextLevel := "0" . nextLevel
         }
         GuiControl,Level:,CurrentLevel, %newLevel%
@@ -93,18 +90,20 @@ SearchLog() {
         {
           tempFileName = %A_LoopFileName%
           StringTrimRight, tempFileName, tempFileName, 4
-          If (tempFileName != "meta" and tempFileName != "class") {
+          If (tempFileName != "meta" and tempFileName != "class") 
+          {
             gemFiles.Push(tempFileName)
           }
         }
         For index, someLevel in gemFiles
         {
-          If ( InStr(someLevel,newLevel) || InStr(someLevel,nextLevel) ) {
-          ;If ((someLevel = newLevel) || (someLevel = newLevel+1)) {
+          If ( InStr(someLevel,newLevel) || InStr(someLevel,nextLevel) ) 
+          {
             GuiControl,Gems:,CurrentGem, % "|" test := GetDelimitedPartListString(gemFiles, someLevel)
             Sleep, 100
             Gui, Gems:Submit, NoHide
-            If (gems_toggle) {
+            If (gems_toggle) 
+            {
               SetGems()
             }
             break
@@ -113,12 +112,12 @@ SearchLog() {
         SaveState()
       }
       beenSlain := "has been slain"
-      IfInString, log, %beenSlain%
+      IfInString, newLogLines, %beenSlain%
       {
         Sleep, 5000
         Send, %KeyOnDeath%
       }
-    }
+    } ;end level up logic
 
     travel := "You have entered"
     IfInString, log, %travel%
@@ -127,10 +126,11 @@ SearchLog() {
       active_toggle := 1
 
       newPartTest := "Lioneye's Watch"
-      IfInString, log, %newPartTest%
+      IfInString, newLogLines, %newPartTest%
       {
         act5LastZone := "45 Cathedral Rooftop"
-        If (CurrentZone = act5LastZone) {
+        If (CurrentZone = act5LastZone)
+        {
           numPart := 2
           CurrentPart := "Part 2"
           GuiControl, Controls:Choose, CurrentPart, % "|" CurrentPart
@@ -138,20 +138,22 @@ SearchLog() {
       }
 
       newPartTest := "Oriath"
-      IfInString, log, %newPartTest%
+      IfInString, newLogLines, %newPartTest%
       {
         act10LastZone := "67 Feeding Trough"
-        If (CurrentZone = act10LastZone) {
+        If (CurrentZone = act10LastZone) 
+        {
           GuiControl, Controls:Choose, CurrentAct, % "|Act 11"
           GuiControl, Controls:Choose, CurrentZone, % "|68 The Templar Laboratory"
         }
       }
 
       newPartTest := "Hideout"
-      IfInString, log, %newPartTest%
+      IfInString, newLogLines, %newPartTest%
       {
         act11LastZone := "68 The Haunted Reliquary"
-        If (CurrentZone = act11LastZone) {
+        If (CurrentZone = act11LastZone) 
+        {
           numPart := 3
           CurrentPart := "Maps"
           GuiControl, Controls:Choose, CurrentPart, % "|" CurrentPart
@@ -159,7 +161,7 @@ SearchLog() {
       }
 
       newPartTest := "Aspirants' Plaza"
-      IfInString, log, %newPartTest%
+      IfInString, newLogLines, %newPartTest%
       {
         CurrentZone := "00 Aspirants' Plaza"
         ; GuiControl, Controls:Choose, CurrentZone, % "|" CurrentZone
@@ -168,16 +170,22 @@ SearchLog() {
       }
 
       newAct := CurrentAct
-      If (numPart != 3) {
+      If (numPart != 3) 
+      {
         ;loop through all of the acts in the current part
-        Loop, 6 {
-          For key, zoneGroup in data.zones {
-            If (zoneGroup.act = newAct) {
-              For k, newZone in zoneGroup.list {
+        Loop, 6 
+        {
+          For key, zoneGroup in data.zones 
+          {
+            If (zoneGroup.act = newAct) 
+            {
+              For k, newZone in zoneGroup.list 
+              {
                 StringTrimLeft, zoneSearch, newZone, 3
-                IfInString, log, %zoneSearch%
+                IfInString, newLogLines, %zoneSearch%
                 {
-                  If (newAct != CurrentAct) {
+                  If (newAct != CurrentAct) 
+                  {
                     GuiControl, Controls:Choose, CurrentAct, % "|" newAct
                     CurrentAct := newAct
                     Sleep 100
@@ -189,9 +197,11 @@ SearchLog() {
                   break 3
                 }
               }
-              If (numPart = 1){
+              If (numPart = 1)
+              {
                 actData := data.p1acts
-              } Else If (numPart = 2) {
+              } Else If (numPart = 2) 
+              {
                 actData := data.p2acts
               }
               newAct := RotateAct("next", actData, newAct)
@@ -199,11 +209,13 @@ SearchLog() {
             }
           }
         }
-      } Else {
+      } Else 
+      {
         ;loop through all of the Maps
-        For key, value in Maps {
+        For key, value in Maps 
+        {
           zoneSearch := "entered " . key . "."
-          IfInString, log, %zoneSearch%
+          IfInString, newLogLines, %zoneSearch%
           {
             conqFound := 0
             GuiControl, Controls:Choose, CurrentZone, % "|" key
@@ -214,19 +226,22 @@ SearchLog() {
           }
         }
       }
-    }
+    } ;end travel logic
 
     ;Conquerer Logic goes here!
-    If (!conqFound) {
+    If (!conqFound) 
+    {
       conqueror := "Veritania, the Redeemer"
-      IfInString, log, %conqueror%
+      IfInString, newLogLines, %conqueror%
       {
         conqFound := 1
         Conquerors["Veritania"].Region := Maps[CurrentZone].Region
         Conquerors["Veritania"].Appearances := Conquerors["Veritania"].Appearances + 1
-        If (Conquerors["Veritania"].Appearances = 5) {
+        If (Conquerors["Veritania"].Appearances = 5) 
+        {
           Conquerors["Veritania"].Appearances = 4
-        } Else If (Conquerors["Veritania"].Appearances = 4) {
+        } Else If (Conquerors["Veritania"].Appearances = 4) 
+        {
           ;Conquerors["Veritania"].Region := ""
           ;Conquerors["Veritania"].Appearances := 0
           numWatchstones := SubStr(CurrentAct, 1, 2)
@@ -239,14 +254,16 @@ SearchLog() {
       }
 
       conqueror := "Drox, the Warlord"
-      IfInString, log, %conqueror%
+      IfInString, newLogLines, %conqueror%
       {
         conqFound := 1
         Conquerors["Drox"].Region := Maps[CurrentZone].Region
         Conquerors["Drox"].Appearances := Conquerors["Drox"].Appearances + 1
-        If (Conquerors["Drox"].Appearances = 5) {
+        If (Conquerors["Drox"].Appearances = 5) 
+        {
           Conquerors["Drox"].Appearances = 4
-        } Else If (Conquerors["Drox"].Appearances = 4) {
+        } Else If (Conquerors["Drox"].Appearances = 4) 
+        {
           ;Conquerors["Drox"].Region := ""
           ;Conquerors["Drox"].Appearances := 0
           numWatchstones := SubStr(CurrentAct, 1, 2)
@@ -259,47 +276,54 @@ SearchLog() {
       }
 
       conqueror := "Baran, the Crusader"
-      IfInString, log, %conqueror%
+      IfInString, newLogLines, %conqueror%
       {
         conqFound := 1
         Conquerors["Baran"].Region := Maps[CurrentZone].Region
         Conquerors["Baran"].Appearances := Conquerors["Baran"].Appearances + 1
-        If (Conquerors["Baran"].Appearances = 5) {
+        If (Conquerors["Baran"].Appearances = 5) 
+        {
           Conquerors["Baran"].Appearances = 4
-        } Else If (Conquerors["Baran"].Appearances = 4) {
+        } Else If (Conquerors["Baran"].Appearances = 4) 
+        {
           ;Conquerors["Baran"].Region := ""
           ;Conquerors["Baran"].Appearances := 0
           numWatchstones := SubStr(CurrentAct, 1, 2)
           numWatchstones++
           GuiControl, Controls:Choose, CurrentAct, % "|" numWatchstones + 1
-        } Else {
+        } Else 
+        {
           GuiControl, Controls:Choose, CurrentAct, % "|" CurrentAct
         }
         ClearConquerors("Baran")
       }
 
       conqueror := "Al-Hezmin, the Hunter"
-      IfInString, log, %conqueror%
+      IfInString, newLogLines, %conqueror%
       {
         conqFound := 1
         Conquerors["Al-Hezmin"].Region := Maps[CurrentZone].Region
         Conquerors["Al-Hezmin"].Appearances := Conquerors["Al-Hezmin"].Appearances + 1
-        If (Conquerors["Al-Hezmin"].Appearances = 5) {
+        If (Conquerors["Al-Hezmin"].Appearances = 5) 
+        {
           Conquerors["Al-Hezmin"].Appearances = 4
-        } Else If (Conquerors["Al-Hezmin"].Appearances = 4) {
+        } Else If (Conquerors["Al-Hezmin"].Appearances = 4) 
+        {
           ;Conquerors["Al-Hezmin"].Region := ""
           ;Conquerors["Al-Hezmin"].Appearances := 0
           numWatchstones := SubStr(CurrentAct, 1, 2)
           numWatchstones++
           GuiControl, Controls:Choose, CurrentAct, % "|" numWatchstones + 1
-        } Else {
+        } Else 
+        {
           GuiControl, Controls:Choose, CurrentAct, % "|" CurrentAct
         }
         ClearConquerors("Al-Hezmin")
       }
-    }
+    } ;end conqueror logic
 
-    If (level_toggle) {
+    If (level_toggle) 
+    {
       SetExp()
     }
   }

--- a/lib/settings.ahk
+++ b/lib/settings.ahk
@@ -145,6 +145,7 @@ LaunchSettings() {
 
   Gui, Settings:Add, Text, w%nameWidth% h%optionHeight% y+25, Tree Side ;Static50
   Gui, Settings:Add, Text, w%nameWidth% h%optionHeight% y+5, Tree File Name ;Static51
+  Gui, Settings:Add, Text, w%nameWidth% h%optionHeight% y+5, Autotoggle Zones ;Static52
 
   Gui, Settings:Add, Edit, vbackgroundColor w%nameWidth% h%optionHeight% x565 y186, %backgroundColor%
   Gui, Settings:Add, Edit, vredColor w%nameWidth% h%optionHeight% y+5, %redColor%
@@ -159,6 +160,7 @@ LaunchSettings() {
 
   Gui, Settings:Add, DropDownList, vtreeSide w%optionWidth% h%dropDownHeight% y+25 x575, % GetRightOrLeft(treeSide)
   Gui, Settings:Add, Edit, vtreeName w%optionWidth% h%optionHeight% y+5, %treeName%
+  Gui, Settings:Add, DropDownList, vautoToggleZoneImages w%optionWidth% h%dropDownHeight% y+5, % GetTrueOrFalse(autoToggleZoneImages)
 
   ;Cancel Button
   Gui, Settings:Add, Button, gCancelAndClose w%nameWidth% x565 y438, &Cancel
@@ -375,6 +377,17 @@ ToolTip() {
     If (toolTime > toolTimeout) {
       ToolTip, This is the multiplier for the full resolution of `nthe zone layout images. A good default value is .5
     }
+  } Else If (control = "static52") { ;Autotoggle Zone images
+    If (oldControl = control){
+          toolTime .= 1
+        } Else {
+          oldControl := control
+          toolTime = 0
+          Tooltip
+        }
+        If (toolTime > toolTimeout) {
+          ToolTip, If enabled will automatically toggle the zone images Disabling them in towns hideouts and enabling them in all other
+        }
   } Else If (control = "static30") { ;Notes X Offset
     If (oldControl = control){
       toolTime .= 1


### PR DESCRIPTION
Recently the tool didnt correctly update zone changes, which is caused by the used Tail function only reading the last line every 200 ms, if any additional line after "entered The coast" is written like "DEBUG: Shaders OFF" the zone change is not processed.

For this the usage of Tail is replaced by using ReadLines on the client.txt file object. This file object is initialised when determining the PoE process, and updated if someone restarts PoE and selects a different client with perhaps a different client.txt location.
Using ReadLines is a straight forward replacement as IfInString can be reused, even though ReadLines may produce multiple lines read since the last update/check.

Also added a setting to automatically enable and disable the zone images: Reason being that the zone images often overlap with the text from the gem-selection from quest rewards. This made it annoying to have to manually toggle the zone images in towns.